### PR TITLE
Fix warning about unsupported i386 architecture

### DIFF
--- a/docs/aws/setup-mainnet-validator-from-scratch.md
+++ b/docs/aws/setup-mainnet-validator-from-scratch.md
@@ -84,7 +84,7 @@ sudo rm -rf /var/lib/casper/*
 
 Execute the following in order to add the Casper repository to `apt` in Ubuntu. 
 ```shell
-echo "deb https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
+echo "deb [arch=amd64] https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
 curl -O https://repo.casperlabs.io/casper-repo-pubkey.asc
 sudo apt-key add casper-repo-pubkey.asc
 sudo apt update

--- a/docs/aws/setup-testnet-validator-from-scratch.md
+++ b/docs/aws/setup-testnet-validator-from-scratch.md
@@ -106,7 +106,7 @@ sudo rm -rf /var/lib/casper/*
 
 Execute the following in order to add the Casper repository to `apt` in Ubuntu. 
 ```shell
-echo "deb https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
+echo "deb [arch=amd64] https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
 curl -O https://repo.casperlabs.io/casper-repo-pubkey.asc
 sudo apt-key add casper-repo-pubkey.asc
 sudo apt update

--- a/docs/ubuntu/setup-mainnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-mainnet-validator-from-scratch.md
@@ -62,7 +62,7 @@ sudo rm -rf /var/lib/casper/*
 
 Execute the following in order to add the Casper repository to `apt` in Ubuntu. 
 ```shell
-echo "deb https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
+echo "deb [arch=amd64] https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
 curl -O https://repo.casperlabs.io/casper-repo-pubkey.asc
 sudo apt-key add casper-repo-pubkey.asc
 sudo apt update

--- a/docs/ubuntu/setup-testnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-testnet-validator-from-scratch.md
@@ -79,7 +79,7 @@ sudo rm -rf /var/lib/casper/*
 
 Execute the following in order to add the Casper repository to `apt` in Ubuntu. 
 ```shell
-echo "deb https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
+echo "deb [arch=amd64] https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
 curl -O https://repo.casperlabs.io/casper-repo-pubkey.asc
 sudo apt-key add casper-repo-pubkey.asc
 sudo apt update

--- a/src/ubuntu/install-casper-node.md
+++ b/src/ubuntu/install-casper-node.md
@@ -2,7 +2,7 @@
 
 Execute the following in order to add the Casper repository to `apt` in Ubuntu. 
 ```shell
-echo "deb https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
+echo "deb [arch=amd64] https://repo.casperlabs.io/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
 curl -O https://repo.casperlabs.io/casper-repo-pubkey.asc
 sudo apt-key add casper-repo-pubkey.asc
 sudo apt update


### PR DESCRIPTION
Full warning:
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://repo.casperlabs.io/releases bionic InRelease' doesn't support architecture 'i386'