### PR TITLE
Update the url for casper-node clone command

### DIFF
--- a/docs/aws/setup-mainnet-validator-from-scratch.md
+++ b/docs/aws/setup-mainnet-validator-from-scratch.md
@@ -135,7 +135,7 @@ Go to your home directory and clone the node repository. Later we will use this 
 ```
 cd ~
 
-git clone git://github.com/CasperLabs/casper-node.git
+git clone https://github.com/casper-network/casper-node.git
 cd casper-node/
 ```
 

--- a/docs/aws/setup-testnet-validator-from-scratch.md
+++ b/docs/aws/setup-testnet-validator-from-scratch.md
@@ -157,7 +157,7 @@ Go to your home directory and clone the node repository. Later we will use this 
 ```
 cd ~
 
-git clone git://github.com/CasperLabs/casper-node.git
+git clone https://github.com/casper-network/casper-node.git
 cd casper-node/
 ```
 

--- a/docs/ubuntu/setup-mainnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-mainnet-validator-from-scratch.md
@@ -113,7 +113,7 @@ Go to your home directory and clone the node repository. Later we will use this 
 ```
 cd ~
 
-git clone git://github.com/CasperLabs/casper-node.git
+git clone https://github.com/casper-network/casper-node.git
 cd casper-node/
 ```
 

--- a/docs/ubuntu/setup-testnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-testnet-validator-from-scratch.md
@@ -130,7 +130,7 @@ Go to your home directory and clone the node repository. Later we will use this 
 ```
 cd ~
 
-git clone git://github.com/CasperLabs/casper-node.git
+git clone https://github.com/casper-network/casper-node.git
 cd casper-node/
 ```
 

--- a/src/ubuntu/setup-validator-from-scratch.md
+++ b/src/ubuntu/setup-validator-from-scratch.md
@@ -70,6 +70,6 @@ Go to your home directory and clone the node repository. Later we will use this 
 ```
 cd ~
 
-git clone git://github.com/CasperLabs/casper-node.git
+git clone https://github.com/casper-network/casper-node.git
 cd casper-node/
 ```


### PR DESCRIPTION
because the unauthenticated git protocol on port 9418 is no longer supported.
For more info: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Signed-off-by: Muhammet Kara <muhammet@make.services>