### PR TITLE
Increase the max db size for Testnet 1.4.5 upgrade

### DIFF
--- a/docs/aws/setup-testnet-validator-from-scratch.md
+++ b/docs/aws/setup-testnet-validator-from-scratch.md
@@ -358,6 +358,11 @@ sudo -u casper /etc/casper/pull_casper_node_version.sh casper-test.conf 1_4_5
 sudo -u casper /etc/casper/config_from_example.sh 1_4_5
 ```
 
+Then to update the max size for your node's database file to a safer point, execute the following command:
+```
+sudo sed -i "/max_global_state_size =/c\max_global_state_size = 1_539_316_278_886" /etc/casper/1_4_5/config.toml
+```
+
 ### Start the node
 
 ```

--- a/docs/ubuntu/setup-testnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-testnet-validator-from-scratch.md
@@ -331,6 +331,11 @@ sudo -u casper /etc/casper/pull_casper_node_version.sh casper-test.conf 1_4_5
 sudo -u casper /etc/casper/config_from_example.sh 1_4_5
 ```
 
+Then to update the max size for your node's database file to a safer point, execute the following command:
+```
+sudo sed -i "/max_global_state_size =/c\max_global_state_size = 1_539_316_278_886" /etc/casper/1_4_5/config.toml
+```
+
 ### Start the node
 
 ```

--- a/src/ubuntu/stage-upgrade.md
+++ b/src/ubuntu/stage-upgrade.md
@@ -108,3 +108,8 @@ Execute the following two commands, one by one:
 sudo -u casper /etc/casper/pull_casper_node_version.sh casper-test.conf 1_4_5
 sudo -u casper /etc/casper/config_from_example.sh 1_4_5
 ```
+
+Then to update the max size for your node's database file to a safer point, execute the following command:
+```
+sudo sed -i "/max_global_state_size =/c\max_global_state_size = 1_539_316_278_886" /etc/casper/1_4_5/config.toml
+```


### PR DESCRIPTION
To avoid node crashes when the limit is exceeded.

Signed-off-by: Muhammet Kara <muhammet@make.services>