### PR TITLE
Lower the default delegation rate to 1% for TestNet

### DIFF
--- a/docs/aws/setup-testnet-validator-from-scratch.md
+++ b/docs/aws/setup-testnet-validator-from-scratch.md
@@ -372,7 +372,7 @@ sudo -u casper casper-client put-deploy \
     --gas-price=1 \
     --session-arg=public_key:"public_key='$PUBLIC_KEY_HEX'" \
     --session-arg=amount:"u512='900000000000'" \
-    --session-arg=delegation_rate:"u8='10'"
+    --session-arg=delegation_rate:"u8='1'"
 ```
 
 #### Argument Explanation

--- a/docs/ubuntu/setup-testnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-testnet-validator-from-scratch.md
@@ -345,7 +345,7 @@ sudo -u casper casper-client put-deploy \
     --gas-price=1 \
     --session-arg=public_key:"public_key='$PUBLIC_KEY_HEX'" \
     --session-arg=amount:"u512='900000000000'" \
-    --session-arg=delegation_rate:"u8='10'"
+    --session-arg=delegation_rate:"u8='1'"
 ```
 
 #### Argument Explanation

--- a/src/casper-client/bond.md
+++ b/src/casper-client/bond.md
@@ -10,7 +10,7 @@ sudo -u casper casper-client put-deploy \
         --gas-price=1 \
         --session-arg=public_key:"public_key='<PUBLIC_KEY_HEX>'" \
         --session-arg=amount:"u512='900000000000'" \
-        --session-arg=delegation_rate:"u8='10'"
+        --session-arg=delegation_rate:"u8='1'"
 ```
 
 Where:

--- a/src/ubuntu/casper-client/bond.md
+++ b/src/ubuntu/casper-client/bond.md
@@ -14,7 +14,7 @@ sudo -u casper casper-client put-deploy \
     --gas-price=1 \
     --session-arg=public_key:"public_key='$PUBLIC_KEY_HEX'" \
     --session-arg=amount:"u512='900000000000'" \
-    --session-arg=delegation_rate:"u8='10'"
+    --session-arg=delegation_rate:"u8='1'"
 ```
 
 #### Argument Explanation


### PR DESCRIPTION
To avoid accumulation of too much tokens on the nodes