### PR TITLE
Update Testnet rewards doc

### DIFF
--- a/docs/aws/setup-testnet-validator-from-scratch.md
+++ b/docs/aws/setup-testnet-validator-from-scratch.md
@@ -406,10 +406,9 @@ casper-client get-auction-info --node-address http://127.0.0.1:7777
 The bid should appear among the returned ```bids```. If the public key associated with a bid appears in the ```validator_weights``` structure for an era, then the account is bonded in that era.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 

--- a/docs/faq-validator.md
+++ b/docs/faq-validator.md
@@ -57,10 +57,10 @@ Yes. You may follow these steps:
 
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
 
-## Is this an incentivised test net? If so, what are the rules for the reward calculation?
+## Is this an incentivised Testnet? If so, what are the rules for the reward calculation?
 All information about the reward program is here: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
-## Where is the faucet to get test net tokens?
+## Where is the faucet to get Testnet tokens?
 [https://testnet.cspr.live/tools/faucet](https://testnet.cspr.live/tools/faucet)
 
 ## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
@@ -71,5 +71,3 @@ No. Number of tokens on your node or being in top-100 based on the number of tok
 * Now go to this address: `https://testnet.cspr.live/validator/PUBLIC-HASH-OF-YOUR-NODE`
 * Make sure that you see the `ACTIVE` (green) label on your node’s page on testnet.cspr.live, and the `LATEST BLOCK HEIGHT` value at the top of the page is the same as the height value from your node’s status output (you took note of that at the first step). (+-3 difference between these values is okay.)
 
-## I've followed the instructions to install my node, but I'm seeing a lot of warnings on the logs about dropping connections and network mismatch. Is that expected?
-Yes. Don't worry about them. When a node from the mainnet tries to connect to another node on the testnet -or the other way around-, the connection gets dropped, causing such warning messages.

--- a/docs/faq-validator.md
+++ b/docs/faq-validator.md
@@ -58,13 +58,13 @@ Yes. You may follow these steps:
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
 
 ## Is this an incentivised test net? If so, what are the rules for the reward calculation?
-All information about the reward program is here: https://docs.cspr.community/docs/testnet-rewards.html
+All information about the reward program is here: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
 ## Where is the faucet to get test net tokens?
-https://testnet.cspr.live/tools/faucet
+[https://testnet.cspr.live/tools/faucet](https://testnet.cspr.live/tools/faucet)
 
 ## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
-No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: https://docs.cspr.community/docs/testnet-rewards.html
+No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
 ## How can I make sure my node is perceived as up & running for reward calculation?
 * Go to this address in a browser and take note of the `height` value at the bottom of the page: `http://IP-ADDRESS-OF-YOUR-NODE:8888/status`

--- a/docs/faq-validator.md
+++ b/docs/faq-validator.md
@@ -56,3 +56,20 @@ Yes. You may follow these steps:
   `CHAIN_NAME=$(curl -s http://127.0.0.1:8888/status | jq -r '.chainspec_name')`
 
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
+
+## Is this an incentivised test net? If so, what are the rules for the reward calculation?
+All information about the reward program is here: https://docs.cspr.community/docs/testnet-rewards.html
+
+## Where is the faucet to get test net tokens?
+https://testnet.cspr.live/tools/faucet
+
+## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
+No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: https://docs.cspr.community/docs/testnet-rewards.html
+
+## How can I make sure my node is perceived as up & running for reward calculation?
+* Go to this address in a browser and take note of the `height` value at the bottom of the page: `http://IP-ADDRESS-OF-YOUR-NODE:8888/status`
+* Now go to this address: `https://testnet.cspr.live/validator/PUBLIC-HASH-OF-YOUR-NODE`
+* Make sure that you see the `ACTIVE` (green) label on your node’s page on testnet.cspr.live, and the `LATEST BLOCK HEIGHT` value at the top of the page is the same as the height value from your node’s status output (you took note of that at the first step). (+-3 difference between these values is okay.)
+
+## I've followed the instructions to install my node, but I'm seeing a lot of warnings on the logs about dropping connections and network mismatch. Is that expected?
+Yes. Don't worry about them. When a node from the mainnet tries to connect to another node on the testnet -or the other way around-, the connection gets dropped, causing such warning messages.

--- a/docs/testnet-rewards.md
+++ b/docs/testnet-rewards.md
@@ -51,7 +51,7 @@ Your cumulative weekly score can be reduced if any of the following events occur
 If your node at any time during the weekly calculation period has a network weight of 6% or more, your score for that 
 week will be reduced by 10%.
 
-#### Validator Bid
+##### Validator Bid
 
 If your node does not have an active bid on the network, it will be considered down, and will not be eligible for rewards. If you follow the installation instructions completely, you will have an active bid. Please see the [Validator FAQ](https://docs.cspr.community/docs/faq-validator.html) for more details on how to monitor your node's bid status, and how to reactivate your bid if it gets deactivated.
 

--- a/docs/testnet-rewards.md
+++ b/docs/testnet-rewards.md
@@ -1,13 +1,13 @@
-# DEVxDAO Casper Testnet Rewards
+# Casper Testnet Rewards
 
 ## Introduction
 
-Thank you for participating in the DEVxDAO's Casper Testnet program. Your voluntary participation in this Testnet is enabling 
+Thank you for participating in the Casper Testnet program. Your voluntary participation in this Testnet is enabling 
 stakeholders across the Casper eco-system, including core node developers, validators, dApp developers and tool developers,
 to test their software in a non-production environment, and to preview upcoming software changes. 
-As announced at the onset of the Testnet program, the DEVxDAO is planning to award grants to Testnet participants, contingent
+As announced at the onset of the Testnet program, it is planned to award rewards to Testnet participants, contingent
 upon their adherence to the [Code of Conduct](testnet.md), based on an algorithmically calculated score that incorporates
-certain performance criteria (see below), and subject to certain limits and final DEVxDAO approval through its governance process.
+certain performance criteria (see below), and subject to certain limits and final approval.
 
 ## Reward Calculation
 
@@ -20,8 +20,8 @@ certain performance criteria (see below), and subject to certain limits and fina
     * `n` is subject to a future vote of the DEVxDAO
     * the ranking each week is calculated as explained below 
     * all participants tied for the last reward-eligible position will be awarded
-* Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and DEVxDAO governance and grant specifics
-* The total reward amount available to the program is subject to a DEVxDAO vote, per its governance rules
+* Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and Casper Association's workflow and grant specifics
+* The total reward amount available to the program is subject to a change as needed with a prior announcement
 * Reward participation is contingent upon completing a KYC/AML process, details for which will be announced at a later date.
 * One KYC'd person can only be tied to one node, for reward purposes.
 
@@ -32,9 +32,15 @@ The basic scoring algorithm is:
 ```shell
 100 * uptime_percentage
 ```
-where `uptime_percentage` is defined as your node running within 1 block from the "tip" of the blockchain. Your node is regularly scanned
+where `uptime_percentage` is defined as your node running within 4 blocks from the "tip" of the blockchain. Your node is regularly scanned
 on port `8888` to check your block height, so if your port `8888` is closed, you are automatically not considered "up". `uptime_percentage`
 is calculated on a 24-hour basis, during each UTC day. 
+
+#### Longevity Score
+
+The he longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
+
+Network longevity at 100% will be used as a factor to break ties (longer longevity=higher ranking among tied performance metrics) and where a tie causes the rewardee list to exceed 100 rewardees, the list will either be shortened to exclude all tied rewardees, or extended up to 110 rewardees, whichever results in fewer rewardee additions/removals.
 
 #### Deductions
 
@@ -42,8 +48,12 @@ Your cumulative weekly score can be reduced if any of the following events occur
 
 ##### Network Weight
 
-If your node at any time during the weekly calculation period has a network weight of 3% or more, your score for that 
-week will be reduced by 10%
+If your node at any time during the weekly calculation period has a network weight of 6% or more, your score for that 
+week will be reduced by 10%.
+
+#### Validator Bid
+
+If your node does not have an active bid on the network, it will be considered down, and will not be eligible for rewards. If you follow the installation instructions completely, you will have an active bid. Please see the [Validator FAQ](https://docs.cspr.community/docs/faq-validator.html) for more details on how to monitor your node's bid status, and how to reactivate your bid if it gets deactivated.
 
 ##### Node Software Version
 

--- a/docs/testnet-rewards.md
+++ b/docs/testnet-rewards.md
@@ -38,7 +38,7 @@ is calculated on a 24-hour basis, during each UTC day.
 
 #### Longevity Score
 
-The he longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
+The longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
 
 Network longevity at 100% will be used as a factor to break ties (longer longevity=higher ranking among tied performance metrics) and where a tie causes the rewardee list to exceed 100 rewardees, the list will either be shortened to exclude all tied rewardees, or extended up to 110 rewardees, whichever results in fewer rewardee additions/removals.
 
@@ -62,9 +62,8 @@ upgrade is slated to take effect, your score for that week will be reduced by 10
 slated for `era 234` and your node is still not upgraded at the beginning of `era 235`, you will lose 10% of your score.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._

--- a/docs/testnet-rewards.md
+++ b/docs/testnet-rewards.md
@@ -17,7 +17,7 @@ certain performance criteria (see below), and subject to certain limits and fina
   Monday April 12th, 2021.
 * Weeks begin on Monday at 0:00:00 UTC, and end on Sunday at 23:59:59 UTC.
 * Rewards are awarded to the top-ranked `n` of Testnet participants in a given week:
-    * `n` is subject to a future vote of the DEVxDAO
+    * `n` is subject to a future decision
     * the ranking each week is calculated as explained below 
     * all participants tied for the last reward-eligible position will be awarded
 * Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and Casper Association's workflow and grant specifics

--- a/docs/testnet.md
+++ b/docs/testnet.md
@@ -1,7 +1,7 @@
 # Casper Testnet
 
 ## Introduction
-Participants in the [DEVxDAO](https://devxdao.com) are standing up a Casper Testnet with the following objectives:
+A Casper Testnet has been bootstrapped with the following objectives:
 * having a permissionless test environment that ecosystem participants can join and use in order to develop, test and tune their tools and 
 applications that eventually target the Casper Mainnet, without the need for Mainnet tokens.
   
@@ -12,7 +12,7 @@ applications that eventually target the Casper Mainnet, without the need for Mai
 applications once said changes deploy to the Casper Mainnet. 
   
 ## Incentivized Participation
-The DEVxDAO (through the ETA, as described below) is inviting interested parties to participate in the Testnet and will offer incentive rewards to Testnet participants. The following
+Casper Association is inviting interested parties to participate in the Testnet and will offer incentive rewards to Testnet participants. The following
 will apply to incentivized participation:
 1. It is intended that rewards will be distributed on the Testnet for a period of time. This will be ratified soon after Testnet is up.
    Everyone will have a *chance* to earn, but not everyone is *guaranteed* (nor is anyone entitled) to earn rewards.
@@ -22,21 +22,19 @@ will apply to incentivized participation:
 3. Testnet Validators will be scored using an algorithm that takes **uptime** and **liveness** into account, among other factors. 
    **BEING IN THE TOP RANKS OF VALIDATORS BY STAKE WEIGHT WILL NOT BE A CRITERIA FOR EARNING REWARDS!**
 
-4. There will also be ACTIVE participation rewards for catching and reporting bugs, winning contests, and other fun things that will be announced periodically as well.
-
-5. Anyone wishing to earn rewards will need to pass AML/KYC and register their Public Key as part of their participation.
+4. Anyone wishing to earn rewards will need to pass AML/KYC and register their Public Key as part of their participation.
 
 ## Testnet Code of Conduct
 It is mandatory that all participants adhere to the Testnet Code of Conduct below. Adherence is taken into consideration for reward calculation.
-1. Join the [Testnet Participants Telegram Group](https://t.me/joinchat/VvtnoteaRVg2ODQx), and be responsive to Admin announcements.
+1. Join the [Testnet Participants Telegram Group](https://t.me/CasperTestNet), and be responsive to Admin announcements.
 2. Make sure your port 8888 is open to the public. It will be monitored for reward calculation purposes.
-3. Once there are 50 or more participants on the network, maintain a stake that is below 3% of the network. There is no benefit to accumulating stake. 
+3. Once there are 50 or more participants on the network, maintain a stake that is below 6% of the network. There is no benefit to accumulating stake. 
    It is not a reward criteria, and Testnet Tokens have no express or implied value whatsoever. 
 4. Stage and participate in node software updates before they are slated to take effect. This requires being attentive for and responsive to notifications
    in the Telegram channel.
 5. If you have to take your node offline, unbond your stake first.
 6. Follow the minimum [Recommended Hardware Specifications](https://docs.casper.network/operators/setup/hardware/)
-7. Participation is entirely at your own risk and you agree to hold ETA, Casper and the DEVxDAO, and their employees, officers, directors, paid consultants
+7. Participation is entirely at your own risk and you agree to hold Casper Association, and their employees, officers, directors, paid consultants
    and agents, harmless from any and all liability.
 
 

--- a/docs/testnet.md
+++ b/docs/testnet.md
@@ -40,9 +40,8 @@ It is mandatory that all participants adhere to the Testnet Code of Conduct belo
    and agents, harmless from any and all liability.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._

--- a/docs/testnet/testnet-upgrades.md
+++ b/docs/testnet/testnet-upgrades.md
@@ -24,12 +24,11 @@
 - [TestNet Upgrade to casper-node v1.5.6](upgrade-1_5_6.md)
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_1_0.md
+++ b/docs/testnet/upgrade-1_1_0.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_1_2.md
+++ b/docs/testnet/upgrade-1_1_2.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_2_0.md
+++ b/docs/testnet/upgrade-1_2_0.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_2_1.md
+++ b/docs/testnet/upgrade-1_2_1.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_3_1.md
+++ b/docs/testnet/upgrade-1_3_1.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_3_2.md
+++ b/docs/testnet/upgrade-1_3_2.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_3_4.md
+++ b/docs/testnet/upgrade-1_3_4.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_1.md
+++ b/docs/testnet/upgrade-1_4_1.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_10.md
+++ b/docs/testnet/upgrade-1_4_10.md
@@ -47,12 +47,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_13.md
+++ b/docs/testnet/upgrade-1_4_13.md
@@ -47,12 +47,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_15.md
+++ b/docs/testnet/upgrade-1_4_15.md
@@ -47,12 +47,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_2.md
+++ b/docs/testnet/upgrade-1_4_2.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_3.md
+++ b/docs/testnet/upgrade-1_4_3.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_4.md
+++ b/docs/testnet/upgrade-1_4_4.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_5.md
+++ b/docs/testnet/upgrade-1_4_5.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_6.md
+++ b/docs/testnet/upgrade-1_4_6.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_7.md
+++ b/docs/testnet/upgrade-1_4_7.md
@@ -46,12 +46,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_4_8.md
+++ b/docs/testnet/upgrade-1_4_8.md
@@ -47,12 +47,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_5_2.md
+++ b/docs/testnet/upgrade-1_5_2.md
@@ -47,12 +47,11 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 
 
 

--- a/docs/testnet/upgrade-1_5_3.md
+++ b/docs/testnet/upgrade-1_5_3.md
@@ -46,10 +46,9 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 

--- a/docs/testnet/upgrade-1_5_5.md
+++ b/docs/testnet/upgrade-1_5_5.md
@@ -46,10 +46,9 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 

--- a/docs/testnet/upgrade-1_5_6.md
+++ b/docs/testnet/upgrade-1_5_6.md
@@ -46,10 +46,9 @@ called `next_upgrade`, which if you successfully staged your upgrade, will have 
 If you see another value here, for example `null`, then your upgrade staging was not executed successfully.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._
 

--- a/docs/ubuntu/setup-testnet-validator-from-scratch.md
+++ b/docs/ubuntu/setup-testnet-validator-from-scratch.md
@@ -379,9 +379,8 @@ casper-client get-auction-info --node-address http://127.0.0.1:7777
 The bid should appear among the returned ```bids```. If the public key associated with a bid appears in the ```validator_weights``` structure for an era, then the account is bonded in that era.
 
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._

--- a/src/disclaimer.md
+++ b/src/disclaimer.md
@@ -1,7 +1,6 @@
 
-_Please note that the DEVxDAO's Casper Testnet program is implemented by the [DEVxDAO](https://devxdao.com) by providing rewards 
-through the [Emerging Technology Association](https://www.emergingte.ch) (ETA), a Swiss nonprofit association which supports open source 
-and transparent scientific research of emerging technologies for community building. 
-Any rewards will be granted and calculated by the ETA. MAKE Technology LLC is not affiliated
-with the DEVxDAO, the ETA nor the Casper Foundation, and has no control over the program sponsorship or the incentivized
-reward program, and is hosting these guides and documents as a service to the DEVxDAO and the Casper community only._
+_Please note that the Casper Testnet program is implemented by providing rewards
+through the [Casper Association](https://casper.network) (CA), a not-for-profit, Switzerland-domiciled organization
+responsible for overseeing the Casper network and supporting its organic evolution and continued decentralization.
+MAKE Technology LLC is not affiliated with the Casper Association, and has no control over the program sponsorship or the incentivized
+reward program, and is hosting these guides and documents as a service to the Casper community only._

--- a/src/faq-validator.md
+++ b/src/faq-validator.md
@@ -50,3 +50,20 @@ Yes. You may follow these steps:
   `CHAIN_NAME=$(curl -s http://127.0.0.1:8888/status | jq -r '.chainspec_name')`
 
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
+
+## Is this an incentivised test net? If so, what are the rules for the reward calculation?
+All information about the reward program is here: https://docs.cspr.community/docs/testnet-rewards.html
+
+## Where is the faucet to get test net tokens?
+https://testnet.cspr.live/tools/faucet
+
+## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
+No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: https://docs.cspr.community/docs/testnet-rewards.html
+
+## How can I make sure my node is perceived as up & running for reward calculation?
+* Go to this address in a browser and take note of the `height` value at the bottom of the page: `http://IP-ADDRESS-OF-YOUR-NODE:8888/status`
+* Now go to this address: `https://testnet.cspr.live/validator/PUBLIC-HASH-OF-YOUR-NODE`
+* Make sure that you see the `ACTIVE` (green) label on your node’s page on testnet.cspr.live, and the `LATEST BLOCK HEIGHT` value at the top of the page is the same as the height value from your node’s status output (you took note of that at the first step). (+-3 difference between these values is okay.)
+
+## I've followed the instructions to install my node, but I'm seeing a lot of warnings on the logs about dropping connections and network mismatch. Is that expected?
+Yes. Don't worry about them. When a node from the mainnet tries to connect to another node on the testnet -or the other way around-, the connection gets dropped, causing such warning messages.

--- a/src/faq-validator.md
+++ b/src/faq-validator.md
@@ -52,13 +52,13 @@ Yes. You may follow these steps:
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
 
 ## Is this an incentivised test net? If so, what are the rules for the reward calculation?
-All information about the reward program is here: https://docs.cspr.community/docs/testnet-rewards.html
+All information about the reward program is here: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
 ## Where is the faucet to get test net tokens?
-https://testnet.cspr.live/tools/faucet
+[https://testnet.cspr.live/tools/faucet](https://testnet.cspr.live/tools/faucet)
 
 ## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
-No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: https://docs.cspr.community/docs/testnet-rewards.html
+No. Number of tokens on your node or being in top-100 based on the number of tokens on your node doesn’t mean anything for reward calculation. Primary criteria for successful participation is the uptime. See here for more information: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
 ## How can I make sure my node is perceived as up & running for reward calculation?
 * Go to this address in a browser and take note of the `height` value at the bottom of the page: `http://IP-ADDRESS-OF-YOUR-NODE:8888/status`

--- a/src/faq-validator.md
+++ b/src/faq-validator.md
@@ -51,10 +51,10 @@ Yes. You may follow these steps:
 
   `sudo -u casper casper-client put-deploy --secret-key /etc/casper/validator_keys/secret_key.pem --chain-name "$CHAIN_NAME" --session-path ~/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm --payment-amount 300000000 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"`
 
-## Is this an incentivised test net? If so, what are the rules for the reward calculation?
+## Is this an incentivised Testnet? If so, what are the rules for the reward calculation?
 All information about the reward program is here: [https://docs.cspr.community/docs/testnet-rewards.html](https://docs.cspr.community/docs/testnet-rewards.html)
 
-## Where is the faucet to get test net tokens?
+## Where is the faucet to get Testnet tokens?
 [https://testnet.cspr.live/tools/faucet](https://testnet.cspr.live/tools/faucet)
 
 ## I see that some nodes have much more tokens bonded/delegated than what I have on my node. Does it mean they will get more rewards?
@@ -65,5 +65,3 @@ No. Number of tokens on your node or being in top-100 based on the number of tok
 * Now go to this address: `https://testnet.cspr.live/validator/PUBLIC-HASH-OF-YOUR-NODE`
 * Make sure that you see the `ACTIVE` (green) label on your node’s page on testnet.cspr.live, and the `LATEST BLOCK HEIGHT` value at the top of the page is the same as the height value from your node’s status output (you took note of that at the first step). (+-3 difference between these values is okay.)
 
-## I've followed the instructions to install my node, but I'm seeing a lot of warnings on the logs about dropping connections and network mismatch. Is that expected?
-Yes. Don't worry about them. When a node from the mainnet tries to connect to another node on the testnet -or the other way around-, the connection gets dropped, causing such warning messages.

--- a/src/testnet-rewards.md
+++ b/src/testnet-rewards.md
@@ -51,7 +51,7 @@ Your cumulative weekly score can be reduced if any of the following events occur
 If your node at any time during the weekly calculation period has a network weight of 6% or more, your score for that 
 week will be reduced by 10%.
 
-#### Validator Bid
+##### Validator Bid
 
 If your node does not have an active bid on the network, it will be considered down, and will not be eligible for rewards. If you follow the installation instructions completely, you will have an active bid. Please see the [Validator FAQ](https://docs.cspr.community/docs/faq-validator.html) for more details on how to monitor your node's bid status, and how to reactivate your bid if it gets deactivated.
 

--- a/src/testnet-rewards.md
+++ b/src/testnet-rewards.md
@@ -38,7 +38,7 @@ is calculated on a 24-hour basis, during each UTC day.
 
 #### Longevity Score
 
-The he longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
+The longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
 
 Network longevity at 100% will be used as a factor to break ties (longer longevity=higher ranking among tied performance metrics) and where a tie causes the rewardee list to exceed 100 rewardees, the list will either be shortened to exclude all tied rewardees, or extended up to 110 rewardees, whichever results in fewer rewardee additions/removals.
 

--- a/src/testnet-rewards.md
+++ b/src/testnet-rewards.md
@@ -1,13 +1,13 @@
-# DEVxDAO Casper Testnet Rewards
+# Casper Testnet Rewards
 
 ## Introduction
 
-Thank you for participating in the DEVxDAO's Casper Testnet program. Your voluntary participation in this Testnet is enabling 
+Thank you for participating in the Casper Testnet program. Your voluntary participation in this Testnet is enabling 
 stakeholders across the Casper eco-system, including core node developers, validators, dApp developers and tool developers,
 to test their software in a non-production environment, and to preview upcoming software changes. 
-As announced at the onset of the Testnet program, the DEVxDAO is planning to award grants to Testnet participants, contingent
+As announced at the onset of the Testnet program, it is planned to award rewards to Testnet participants, contingent
 upon their adherence to the [Code of Conduct](testnet.md), based on an algorithmically calculated score that incorporates
-certain performance criteria (see below), and subject to certain limits and final DEVxDAO approval through its governance process.
+certain performance criteria (see below), and subject to certain limits and final approval.
 
 ## Reward Calculation
 
@@ -20,8 +20,8 @@ certain performance criteria (see below), and subject to certain limits and fina
     * `n` is subject to a future vote of the DEVxDAO
     * the ranking each week is calculated as explained below 
     * all participants tied for the last reward-eligible position will be awarded
-* Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and DEVxDAO governance and grant specifics
-* The total reward amount available to the program is subject to a DEVxDAO vote, per its governance rules
+* Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and Casper Association's workflow and grant specifics
+* The total reward amount available to the program is subject to a change as needed with a prior announcement
 * Reward participation is contingent upon completing a KYC/AML process, details for which will be announced at a later date.
 * One KYC'd person can only be tied to one node, for reward purposes.
 
@@ -32,9 +32,15 @@ The basic scoring algorithm is:
 ```shell
 100 * uptime_percentage
 ```
-where `uptime_percentage` is defined as your node running within 1 block from the "tip" of the blockchain. Your node is regularly scanned
+where `uptime_percentage` is defined as your node running within 4 blocks from the "tip" of the blockchain. Your node is regularly scanned
 on port `8888` to check your block height, so if your port `8888` is closed, you are automatically not considered "up". `uptime_percentage`
 is calculated on a 24-hour basis, during each UTC day. 
+
+#### Longevity Score
+
+The he longevity score is the cumulative daily score of a node since the last fault. Any day with a score below 90 is considered a fault.
+
+Network longevity at 100% will be used as a factor to break ties (longer longevity=higher ranking among tied performance metrics) and where a tie causes the rewardee list to exceed 100 rewardees, the list will either be shortened to exclude all tied rewardees, or extended up to 110 rewardees, whichever results in fewer rewardee additions/removals.
 
 #### Deductions
 
@@ -42,8 +48,12 @@ Your cumulative weekly score can be reduced if any of the following events occur
 
 ##### Network Weight
 
-If your node at any time during the weekly calculation period has a network weight of 3% or more, your score for that 
-week will be reduced by 10%
+If your node at any time during the weekly calculation period has a network weight of 6% or more, your score for that 
+week will be reduced by 10%.
+
+#### Validator Bid
+
+If your node does not have an active bid on the network, it will be considered down, and will not be eligible for rewards. If you follow the installation instructions completely, you will have an active bid. Please see the [Validator FAQ](https://docs.cspr.community/docs/faq-validator.html) for more details on how to monitor your node's bid status, and how to reactivate your bid if it gets deactivated.
 
 ##### Node Software Version
 

--- a/src/testnet-rewards.md
+++ b/src/testnet-rewards.md
@@ -17,7 +17,7 @@ certain performance criteria (see below), and subject to certain limits and fina
   Monday April 12th, 2021.
 * Weeks begin on Monday at 0:00:00 UTC, and end on Sunday at 23:59:59 UTC.
 * Rewards are awarded to the top-ranked `n` of Testnet participants in a given week:
-    * `n` is subject to a future vote of the DEVxDAO
+    * `n` is subject to a future decision
     * the ranking each week is calculated as explained below 
     * all participants tied for the last reward-eligible position will be awarded
 * Rewards are accrued and paid at a later date, subject to Casper token lock-up periods and Casper Association's workflow and grant specifics

--- a/src/testnet.md
+++ b/src/testnet.md
@@ -1,7 +1,7 @@
 # Casper Testnet
 
 ## Introduction
-Participants in the [DEVxDAO](https://devxdao.com) are standing up a Casper Testnet with the following objectives:
+A Casper Testnet has been bootstrapped with the following objectives:
 * having a permissionless test environment that ecosystem participants can join and use in order to develop, test and tune their tools and 
 applications that eventually target the Casper Mainnet, without the need for Mainnet tokens.
   
@@ -12,7 +12,7 @@ applications that eventually target the Casper Mainnet, without the need for Mai
 applications once said changes deploy to the Casper Mainnet. 
   
 ## Incentivized Participation
-The DEVxDAO (through the ETA, as described below) is inviting interested parties to participate in the Testnet and will offer incentive rewards to Testnet participants. The following
+Casper Association is inviting interested parties to participate in the Testnet and will offer incentive rewards to Testnet participants. The following
 will apply to incentivized participation:
 1. It is intended that rewards will be distributed on the Testnet for a period of time. This will be ratified soon after Testnet is up.
    Everyone will have a *chance* to earn, but not everyone is *guaranteed* (nor is anyone entitled) to earn rewards.
@@ -22,21 +22,19 @@ will apply to incentivized participation:
 3. Testnet Validators will be scored using an algorithm that takes **uptime** and **liveness** into account, among other factors. 
    **BEING IN THE TOP RANKS OF VALIDATORS BY STAKE WEIGHT WILL NOT BE A CRITERIA FOR EARNING REWARDS!**
 
-4. There will also be ACTIVE participation rewards for catching and reporting bugs, winning contests, and other fun things that will be announced periodically as well.
-
-5. Anyone wishing to earn rewards will need to pass AML/KYC and register their Public Key as part of their participation.
+4. Anyone wishing to earn rewards will need to pass AML/KYC and register their Public Key as part of their participation.
 
 ## Testnet Code of Conduct
 It is mandatory that all participants adhere to the Testnet Code of Conduct below. Adherence is taken into consideration for reward calculation.
-1. Join the [Testnet Participants Telegram Group](https://t.me/joinchat/VvtnoteaRVg2ODQx), and be responsive to Admin announcements.
+1. Join the [Testnet Participants Telegram Group](https://t.me/CasperTestNet), and be responsive to Admin announcements.
 2. Make sure your port 8888 is open to the public. It will be monitored for reward calculation purposes.
-3. Once there are 50 or more participants on the network, maintain a stake that is below 3% of the network. There is no benefit to accumulating stake. 
+3. Once there are 50 or more participants on the network, maintain a stake that is below 6% of the network. There is no benefit to accumulating stake. 
    It is not a reward criteria, and Testnet Tokens have no express or implied value whatsoever. 
 4. Stage and participate in node software updates before they are slated to take effect. This requires being attentive for and responsive to notifications
    in the Telegram channel.
 5. If you have to take your node offline, unbond your stake first.
 6. Follow the minimum [Recommended Hardware Specifications](https://docs.casper.network/operators/setup/hardware/)
-7. Participation is entirely at your own risk and you agree to hold ETA, Casper and the DEVxDAO, and their employees, officers, directors, paid consultants
+7. Participation is entirely at your own risk and you agree to hold Casper Association, and their employees, officers, directors, paid consultants
    and agents, harmless from any and all liability.
 
 [include disclaimer.md]


### PR DESCRIPTION
    - Add longevity description
    - Add more explicit active bid requirement
    - Update the network weight threshold
    - Update the uptime block buffer to 4
    - Remove refs to DxD on the requirements page
    - Extend the validator FAQ
    
    These have been well-documented in various places,
    and communicated through the official comms channel
    on Telegram before. Although we haven't got any complaints
    about anyone not knowing these rules, based on community feedback,
    we are adding here explicitly to make it more accessible
    and easier to notice for the newcomers.
